### PR TITLE
Fixed Instant death mishadling of entity health

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,8 +1,8 @@
 # Sets default memory used for gradle commands. Can be overridden by user or command line properties.
 # This is required to provide enough memory for the Minecraft decompilation process.
 org.gradle.jvmargs=-Xmx3G
-mod_version=3.1.0
+mod_version=3.1.1ViperPatch
 mc_version=1.15.2
-forge_version=31.1.0
+forge_version=31.2.45
 mapping=20200202
 jei_version=6.0.0.2

--- a/src/main/java/com/tfar/randomenchants/ench/enchantment/EnchantmentInstantDeath.java
+++ b/src/main/java/com/tfar/randomenchants/ench/enchantment/EnchantmentInstantDeath.java
@@ -64,7 +64,7 @@ public class EnchantmentInstantDeath extends Enchantment {
 //            System.out.println("Victim Health: " + victim.getHealth());
 //            System.out.println("Victim Max Health: " + victim.getMaxHealth());
 //            System.out.println("Victim Total Armor Value: " + victim.getTotalArmorValue());
-            victim.attackEntityFrom(DamageSource.MAGIC, (victimHealth + victimArmor * 2));
+            victim.attackEntityFrom(DamageSource.GENERIC, ((victimHealth + victimArmor) * 2));
 
         }
     }

--- a/src/main/java/com/tfar/randomenchants/ench/enchantment/EnchantmentInstantDeath.java
+++ b/src/main/java/com/tfar/randomenchants/ench/enchantment/EnchantmentInstantDeath.java
@@ -58,7 +58,13 @@ public class EnchantmentInstantDeath extends Enchantment {
         if (target instanceof LivingEntity) {
             LivingEntity victim = (LivingEntity) target;
             float victimHealth = victim.getMaxHealth();
-            victim.attackEntityFrom(DamageSource.MAGIC, (victimHealth * 2));
+            float victimArmor = victim.getTotalArmorValue();
+            // Debug:
+//            System.out.println("Victim Absorption Amount: " + victim.getAbsorptionAmount());
+//            System.out.println("Victim Health: " + victim.getHealth());
+//            System.out.println("Victim Max Health: " + victim.getMaxHealth());
+//            System.out.println("Victim Total Armor Value: " + victim.getTotalArmorValue());
+            victim.attackEntityFrom(DamageSource.MAGIC, (victimHealth + victimArmor * 2));
 
         }
     }

--- a/src/main/java/com/tfar/randomenchants/ench/enchantment/EnchantmentInstantDeath.java
+++ b/src/main/java/com/tfar/randomenchants/ench/enchantment/EnchantmentInstantDeath.java
@@ -1,59 +1,65 @@
 package com.tfar.randomenchants.ench.enchantment;
 
+import static com.tfar.randomenchants.Config.Restriction.ANVIL;
+import static com.tfar.randomenchants.Config.Restriction.DISABLED;
+import static com.tfar.randomenchants.Config.Restriction.NORMAL;
+import static com.tfar.randomenchants.RandomEnchants.SWORDS_BOWS;
+
 import com.tfar.randomenchants.Config;
+
 import net.minecraft.enchantment.Enchantment;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.inventory.EquipmentSlotType;
 import net.minecraft.item.ItemStack;
-
-import static com.tfar.randomenchants.Config.Restriction.*;
-import static com.tfar.randomenchants.RandomEnchants.SWORDS_BOWS;
+import net.minecraft.util.DamageSource;
 
 public class EnchantmentInstantDeath extends Enchantment {
-  public EnchantmentInstantDeath() {
+    public EnchantmentInstantDeath() {
 
-    super(Rarity.RARE, SWORDS_BOWS, new EquipmentSlotType[]{
-            EquipmentSlotType.MAINHAND
-    });
-    this.setRegistryName("instant_death");
-  }
-
-  @Override
-  public int getMinEnchantability(int level) {
-    return 15;
-  }
-
-  @Override
-  public int getMaxLevel() {
-    return 1;
-  }
-
-  @Override
-  public boolean canApply(ItemStack stack){
-    return Config.ServerConfig.instant_death.get() != DISABLED && super.canApply(stack);
-  }
-
-  @Override
-  public boolean isTreasureEnchantment() {
-    return Config.ServerConfig.instant_death.get() == ANVIL;
-  }
-
-  @Override
-  public boolean canApplyAtEnchantingTable(ItemStack stack) {
-    return Config.ServerConfig.instant_death.get() != DISABLED && super.canApplyAtEnchantingTable(stack);
-  }
-
-  @Override
-  public boolean isAllowedOnBooks() {
-    return Config.ServerConfig.instant_death.get() == NORMAL;
-  }
-
-  @Override
-  public void onEntityDamaged(LivingEntity user, Entity target, int level) {
-    if (target instanceof LivingEntity) {
-      LivingEntity victim = (LivingEntity) target;
-      victim.setHealth(0);
+        super(Rarity.RARE, SWORDS_BOWS, new EquipmentSlotType[] {
+                EquipmentSlotType.MAINHAND
+        });
+        this.setRegistryName("instant_death");
     }
-  }
+
+    @Override
+    public int getMinEnchantability(int level) {
+        return 15;
+    }
+
+    @Override
+    public int getMaxLevel() {
+        return 1;
+    }
+
+    @Override
+    public boolean canApply(ItemStack stack) {
+        return Config.ServerConfig.instant_death.get() != DISABLED && super.canApply(stack);
+    }
+
+    @Override
+    public boolean isTreasureEnchantment() {
+        return Config.ServerConfig.instant_death.get() == ANVIL;
+    }
+
+    @Override
+    public boolean canApplyAtEnchantingTable(ItemStack stack) {
+        return Config.ServerConfig.instant_death.get() != DISABLED && super.canApplyAtEnchantingTable(stack);
+    }
+
+    @Override
+    public boolean isAllowedOnBooks() {
+        return Config.ServerConfig.instant_death.get() == NORMAL;
+    }
+
+    @Override
+    public void onEntityDamaged(LivingEntity user, Entity target, int level) {
+        if (target instanceof LivingEntity) {
+            LivingEntity victim = (LivingEntity) target;
+            float victimHealth = victim.getMaxHealth();
+            victim.attackEntityFrom(DamageSource.MAGIC, (victimHealth * 2));
+
+        }
+    }
 }


### PR DESCRIPTION
Fixed the mishandling of an entities health with InstantDeath enchant that would cause item loss and no registration of entities death.