### PR TITLE
Add string for dungeoneering enchant (1.16)

### DIFF
--- a/src/main/resources/assets/randomenchants/lang/en_us.json
+++ b/src/main/resources/assets/randomenchants/lang/en_us.json
@@ -53,6 +53,7 @@
     "enchantment.randomenchants.cursed_jump.desc": "Struck enemies have a cursed jump",
     "enchantment.randomenchants.deflect.desc": "Why protect from the arrow when it can be vaporized",
     "enchantment.randomenchants.disarm.desc": "Your weapon is now mine",
+    "enchantment.randomenchants.dungeoneering.desc": "Is that a dungeon in your pocket?",
     "enchantment.randomenchants.equal_mine.desc": "High hardness? this should level the mining time",
     "enchantment.randomenchants.exploding.desc": "Exploding arrows. Boom.",
     "enchantment.randomenchants.floating.desc": "Your enemies seem to have lost their footing",

--- a/src/main/resources/assets/randomenchants/lang/en_us.json
+++ b/src/main/resources/assets/randomenchants/lang/en_us.json
@@ -5,6 +5,7 @@
     "enchantment.randomenchants.deflect": "Deflect",
     "enchantment.randomenchants.disarm": "Disarm",
     "enchantment.randomenchants.discord": "Discord",
+    "enchantment.randomenchants.dungeoneering": "Dungeoneering",
     "enchantment.randomenchants.equal_mine": "Equal Mine",
     "enchantment.randomenchants.exploding": "Exploding",
     "enchantment.randomenchants.floating": "Floating",


### PR DESCRIPTION
I saw that the dungeoneering enchant didn't have a string, so I thought I would send a quick PR adding one. I made the change in the 1.14-1.16 branches, so I'll be creating two more PRs after this one